### PR TITLE
fix: correctly infer the function type that returns an array

### DIFF
--- a/packages/compiler-api-helper/src/compiler-api-helper.test.ts
+++ b/packages/compiler-api-helper/src/compiler-api-helper.test.ts
@@ -665,7 +665,7 @@ describe('convertType', () => {
         return
       }
 
-      const [type0, type1, type2] = typesResult.ok
+      const [type0, type1, type2, type3] = typesResult.ok
       expect(type0).toBeDefined()
 
       expect(type0?.type).toStrictEqual({
@@ -713,7 +713,19 @@ describe('convertType', () => {
         },
       ])
 
-      expect(type2).not.toBeDefined()
+      expect(type2?.type).toStrictEqual({
+        __type: 'CallableTO',
+        argTypes: [],
+        returnType: {
+          __type: 'ArrayTO',
+          typeName: 'string[]',
+          child: {
+            __type: 'PrimitiveTO',
+            kind: 'string',
+          },
+        },
+      })
+      expect(type3).not.toBeDefined()
     })
 
     describe('promise', () => {

--- a/packages/compiler-api-helper/src/compiler-api-helper.ts
+++ b/packages/compiler-api-helper/src/compiler-api-helper.ts
@@ -464,7 +464,7 @@ export class CompilerApiHelper {
       )
       .case<to.ArrayTO>(
         ({ type, typeText }) =>
-          typeText.endsWith('[]') ||
+          (!this.#isCallable(type) && typeText.endsWith('[]')) ||
           dangerouslySymbolToEscapedName(type.symbol) === 'Array',
         ({ type, typeText }) => ({
           __type: 'ArrayTO',

--- a/packages/example/src/types/function.ts
+++ b/packages/example/src/types/function.ts
@@ -2,3 +2,6 @@ export type Func = (arg: string) => number
 export type HaveMethod = {
   method: (arg: string) => number
 }
+export const funcReturnArray = () => {
+  return ['1']
+}


### PR DESCRIPTION
before:
![Snipaste_2024-05-18_22-37-33](https://github.com/d-kimuson/ts-type-expand/assets/21942252/765620ea-54f6-48db-8b8a-adceadf4bf32)

after:
![Snipaste_2024-05-18_22-38-41](https://github.com/d-kimuson/ts-type-expand/assets/21942252/93e7a721-2b5c-496a-b8ec-dd42c8da0999)
